### PR TITLE
MERGE BUFFERS, CHANNEL, ALLOCATION REWORK:

### DIFF
--- a/Channel.cpp
+++ b/Channel.cpp
@@ -1,0 +1,77 @@
+#include "Channel.hpp"
+#include "irc.hpp"
+
+Channel::Channel()
+{
+	this->_nbOfClients = 0;
+}
+
+Channel::~Channel()
+{
+}
+
+Channel::Channel(std::string name) :  _nbOfClients(0), _name(name)
+{
+}
+
+Channel::Channel(const Channel &source)
+{
+	*this = source;
+}
+
+Channel &Channel::operator=(const Channel &rhs)
+{
+	this->_nbOfClients = rhs._nbOfClients;
+	this->_name = rhs._name;
+	return (*this);
+}
+
+bool Channel::operator<(const Channel &rhs) const
+{
+	return (this->_name < rhs._name);
+}
+
+std::string	Channel::getName() const
+{
+	return (this->_name);
+}
+
+void	Channel::updateChannelName(std::string name)
+{
+	this->_name = name;
+}
+
+int		Channel::isUserConnected(Client& user)
+{
+	std::set<Client*>::iterator it = this->_connectedClients.find(&user);
+	if (it != this->_connectedClients.end())
+		return (CONNECTED);
+	return (NOT_CONNECTED);
+}
+
+void	Channel::connectUser(Client& user)
+{
+	if (this->isUserConnected(user) == NOT_CONNECTED)
+	{
+		this->_connectedClients.insert(&user);
+		this->_nbOfClients++;
+		user.joinChannel(*this);
+	}
+}
+
+/* returns the number of connected clients after the operation to delete chan if empty*/
+int		Channel::disconnectUser(Client& user)
+{
+	if (this->isUserConnected(user) == CONNECTED)
+	{
+		this->_nbOfClients--;
+		std::set<Channel*>::iterator channelIterator = user._connectedChannels.find(this);
+		if (channelIterator != user._connectedChannels.end())
+			user._connectedChannels.erase(channelIterator);
+
+		std::set<Client*>::iterator clientIterator = this->_connectedClients.find(&user);
+		if (clientIterator != this->_connectedClients.end())
+			this->_connectedClients.erase(&user);
+	}
+	return (this->_nbOfClients);
+}

--- a/Channel.hpp
+++ b/Channel.hpp
@@ -1,0 +1,35 @@
+#ifndef CHANNEL_HPP
+# define CHANNEL_HPP
+
+#include <string>
+#include <set>
+
+class Client;
+class Channel
+{
+	public:
+		Channel();
+		~Channel();
+		Channel(const Channel &source);
+		Channel &operator=(const Channel &rhs);
+		bool operator<(const Channel &rhs) const;
+		Channel(std::string name);
+
+		void	updateChannelName(std::string);
+
+		/* getters */
+		std::string getName() const;
+
+		/* users handler */
+		int		isUserConnected(Client& user);
+		int		disconnectUser(Client& user);
+		void	connectUser(Client&);
+
+	private:
+		int					_nbOfClients;
+		std::string			_name;
+		std::set<Client*>	_connectedClients;
+	protected:
+};
+
+#endif

--- a/Channel.hpp
+++ b/Channel.hpp
@@ -2,18 +2,17 @@
 # define CHANNEL_HPP
 
 #include <string>
-#include <set>
+#include <map>
 
 class Client;
 class Channel
 {
 	public:
-		Channel();
 		~Channel();
 		Channel(const Channel &source);
 		Channel &operator=(const Channel &rhs);
 		bool operator<(const Channel &rhs) const;
-		Channel(std::string name);
+		Channel(std::string name, Client& owner);
 
 		void	updateChannelName(std::string);
 
@@ -22,13 +21,15 @@ class Channel
 
 		/* users handler */
 		int		isUserConnected(Client& user);
-		int		disconnectUser(Client& user);
-		void	connectUser(Client&);
+		int		removeUserFromChannel(Client& user);
+		void	addUserToChannel(Client&);
 
 	private:
+		Channel();
+		Client*				_owner;
 		int					_nbOfClients;
 		std::string			_name;
-		std::set<Client*>	_connectedClients;
+		std::map<int, Client*>	_connectedClients;
 	protected:
 };
 

--- a/Client.cpp
+++ b/Client.cpp
@@ -7,7 +7,9 @@ Client::Client()
 
 Client::~Client()
 {
-	close(this->_socketFD);
+	std::cout << "Channel Client start" << std::endl;
+	//close(this->_socketFD);
+	std::cout << "Channel Client end" << std::endl;
 }
 
 Client::Client(int socketFD) : _socketFD(socketFD)
@@ -22,6 +24,7 @@ Client::Client(const Client &source)
 Client& Client::operator=(const Client &rhs)
 {
 	this->_socketFD = rhs._socketFD;
+	this->_username = rhs._username;
 	return (*this);
 }
 
@@ -42,7 +45,12 @@ int	Client::isInChannel(Channel& toFind) const
 	return (NOT_CONNECTED);
 }
 
-void	Client::joinChannel(Channel& toJoin)
+void	Client::joinChannel(Channel& channelToJoin)
 {
-	this->_connectedChannels.insert(&toJoin);
+	this->_connectedChannels.insert(&channelToJoin);
+}
+
+void	Client::quitChannel(Channel& channelToQuit)
+{
+	this->_connectedChannels.erase(&channelToQuit);
 }

--- a/Client.cpp
+++ b/Client.cpp
@@ -34,3 +34,15 @@ int	Client::getSocketFD() const
 {
 	return (this->_socketFD);
 }
+
+int	Client::isInChannel(Channel& toFind) const
+{
+	if (this->_connectedChannels.find(&toFind) != this->_connectedChannels.end())
+		return (CONNECTED);
+	return (NOT_CONNECTED);
+}
+
+void	Client::joinChannel(Channel& toJoin)
+{
+	this->_connectedChannels.insert(&toJoin);
+}

--- a/Client.hpp
+++ b/Client.hpp
@@ -4,6 +4,7 @@
 
 #include "irc.hpp"
 
+class Channel;
 class Client
 {
 	public:
@@ -17,6 +18,11 @@ class Client
 
 		std::string	readBuffer;
 		std::string writeBuffer;
+
+		/* channel handlers */
+		int		isInChannel(Channel&) const;
+		void	joinChannel(Channel&);
+		std::set<Channel*> _connectedChannels;
 	private:
 		Client();
 		Client(const Client &source);

--- a/Client.hpp
+++ b/Client.hpp
@@ -9,6 +9,8 @@ class Client
 {
 	public:
 		~Client();
+		Client(const Client &source);
+		Client& operator=(const Client &rhs);
 		Client(int);
 
 		void	setUsername(std::string name);
@@ -22,15 +24,14 @@ class Client
 		/* channel handlers */
 		int		isInChannel(Channel&) const;
 		void	joinChannel(Channel&);
-		std::set<Channel*> _connectedChannels;
+		void	quitChannel(Channel&);
 	private:
 		Client();
-		Client(const Client &source);
-		Client& operator=(const Client &rhs);
 
 		/* Attributes */
 		int			_socketFD;
 		std::string	_username;
+		std::set<Channel*> _connectedChannels;
 	protected:
 };
 

--- a/Client.hpp
+++ b/Client.hpp
@@ -15,7 +15,8 @@ class Client
 		/* Getters */
 		int	getSocketFD() const;
 
-		char	buffer[IRC_BUFFER_SIZE];
+		std::string	readBuffer;
+		std::string writeBuffer;
 	private:
 		Client();
 		Client(const Client &source);
@@ -26,6 +27,5 @@ class Client
 		std::string	_username;
 	protected:
 };
-
 
 #endif

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test: $(NAME)
 		./$(NAME)
 
 vtest:	$(NAME)
-		valgrind --leak-check=full ./$(NAME)
+		valgrind --leak-check=full --track-fds=yes ./$(NAME)
 
 -include $(DEPS)
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ NAME = ircserv
 
 SRCS =	main.cpp\
 		Server.cpp\
-		Client.cpp
+		Client.cpp\
+		Channel.cpp
 
 CXX = c++
 

--- a/Server.cpp
+++ b/Server.cpp
@@ -1,4 +1,4 @@
-#include "Server.hpp"
+#include "irc.hpp"
 
 Server::Server()
 {
@@ -353,5 +353,43 @@ void	Server::writeLoop()
 			}
 		}
 		it++;
+	}
+}
+
+
+void	Server::createChannel(std::string newChannelName)
+{
+	int	channelAlreadyExists = 0;
+	for (std::set<Channel>::iterator it = this->_channels.begin();
+			it != this->_channels.end(); it++)
+	{
+		if (it->getName() == newChannelName)
+			channelAlreadyExists = 1;
+	}
+	if (channelAlreadyExists == 0)
+	{
+		std::pair<std::set<Channel>::iterator, bool> newlyCreatedChannel;
+		newlyCreatedChannel = this->_channels.insert(Channel());
+		newlyCreatedChannel.first->updateChannelName(newChannelName);
+	}
+}
+
+void	Server::destroyChannel(Channel&)
+{
+}
+
+void	Server::destroyChannel(std::string newChannelName)
+{
+	int	channelAlreadyExists = 0;
+	for (std::set<Channel>::iterator it = this->_channels.begin();
+			it != this->_channels.end(); it++)
+	{
+		if (it->getName() == newChannelName)
+			channelAlreadyExists = 1;
+	}
+	if (channelAlreadyExists == 0)
+	{
+		std::pair<std::set<Channel>::iterator, bool> newlyCreatedChannel;
+		newlyCreatedChannel = this->_channels.insert(Channel());
 	}
 }

--- a/Server.hpp
+++ b/Server.hpp
@@ -18,6 +18,7 @@
 # define MYIRC_TIMEOUT 30
 
 class Client;
+class Channel;
 class Server
 {
 	public:
@@ -40,6 +41,11 @@ class Server
 		void	addUser(int);
 		void	deleteUser(int);
 		void	checkNewConnections();
+
+		/* Channel handlers */
+		void	createChannel(std::string);
+		void	destroyChannel(Channel&);
+		void	destroyChannel(std::string);
 
 		/* read/write loops and set handler */
 		int		fillSets();
@@ -71,6 +77,7 @@ class Server
 		struct sockaddr_storage	_pendingAddr;
 		socklen_t				_pendingAddrSize;
 		char	buffer[IRC_BUFFER_SIZE];
+		std::set<Channel>	_channels;
 };
 
 

--- a/Server.hpp
+++ b/Server.hpp
@@ -25,17 +25,13 @@ class Server
 		Server();
 		~Server();
 		Server(const char *portNumber, const char *domain = NULL);
-		Server(const Server &source);
-		Server& operator=(const Server &rhs);
 
 		void	closeSocketFD();
 		void	socketErrorHandler(int errorBitField) const;
 
 		/* Getters */
 		int		getSocketFD() const;
-		struct addrinfo *getServinfo() const;
-		struct sockaddr *getSockaddr() const;
-		std::set<Client*> &getClients();
+		std::map<int, Client> &getClients();
 
 		/* Client handlers */
 		void	addUser(int);
@@ -65,12 +61,12 @@ class Server
 				const char* what(void) const throw();
 		};
 	private:
+		Server(const Server &source);
+		Server& operator=(const Server &rhs);
 	protected:
-		struct addrinfo	hints;
-		struct addrinfo	*_servinfo;
 		int				_socketFD;
 		int				_fdMax;
-		std::set<Client*> _clients;
+		std::map<int, Client> _clients;
 		fd_set		_masterSet;
 		fd_set		_readingSet;
 		fd_set		_writingSet;

--- a/Server.hpp
+++ b/Server.hpp
@@ -2,7 +2,6 @@
 # define SERVER_HPP
 
 #include "irc.hpp"
-# include <set>
 # include "Client.hpp"
 # include <exception>
 
@@ -12,11 +11,6 @@
 # define ERRSOCKBIND 0b1000
 # define ERRSOCKLISTEN 0b10000
 
-# define MYIRC_PORT "3490"
-# define MYIRC_ALLOWED_PENDING_CONNECTIONS 5
-
-# define MYIRC_TIMEOUT 30
-
 class Client;
 class Channel;
 class Server
@@ -25,6 +19,8 @@ class Server
 		Server();
 		~Server();
 		Server(const char *portNumber, const char *domain = NULL);
+		Server(const Server &source);
+		Server& operator=(const Server &rhs);
 
 		void	closeSocketFD();
 		void	socketErrorHandler(int errorBitField) const;
@@ -35,12 +31,13 @@ class Server
 
 		/* Client handlers */
 		void	addUser(int);
-		void	deleteUser(int);
+		void	disconnectUser(int);
+		void	disconnectUser(std::map<int, Client>::iterator clientIterator);
 		void	checkNewConnections();
 
 		/* Channel handlers */
-		void	createChannel(std::string);
-		void	destroyChannel(Channel&);
+		void	createChannel(std::string, Client&);
+		void	destroyChannel(const Channel&);
 		void	destroyChannel(std::string);
 
 		/* read/write loops and set handler */
@@ -61,8 +58,6 @@ class Server
 				const char* what(void) const throw();
 		};
 	private:
-		Server(const Server &source);
-		Server& operator=(const Server &rhs);
 	protected:
 		int				_socketFD;
 		int				_fdMax;
@@ -73,7 +68,7 @@ class Server
 		struct sockaddr_storage	_pendingAddr;
 		socklen_t				_pendingAddrSize;
 		char	buffer[IRC_BUFFER_SIZE];
-		std::set<Channel>	_channels;
+		std::list<Channel>	_channels;
 };
 
 

--- a/Server.hpp
+++ b/Server.hpp
@@ -70,7 +70,7 @@ class Server
 		fd_set		_writingSet;
 		struct sockaddr_storage	_pendingAddr;
 		socklen_t				_pendingAddrSize;
-
+		char	buffer[IRC_BUFFER_SIZE];
 };
 
 

--- a/irc.hpp
+++ b/irc.hpp
@@ -1,6 +1,11 @@
 #ifndef IRC_HPP
 # define IRC_HPP
+
 # define IRC_BUFFER_SIZE 80
+# define MYIRC_PORT "3490"
+# define MYIRC_ALLOWED_PENDING_CONNECTIONS 5
+# define MYIRC_TIMEOUT 30
+
 # define CONNECTED 1
 # define NOT_CONNECTED 0
 
@@ -18,11 +23,13 @@
 # include <fcntl.h>
 # include <sys/time.h>
 # include <sys/select.h>
+# include <set>
+# include <list>
+# include <map>
+# include <exception>
 # include "Server.hpp"
 # include "Client.hpp"
 # include "Channel.hpp"
-# include <set>
-# include <exception>
 
 
 #endif

--- a/irc.hpp
+++ b/irc.hpp
@@ -1,6 +1,8 @@
 #ifndef IRC_HPP
 # define IRC_HPP
 # define IRC_BUFFER_SIZE 80
+# define CONNECTED 1
+# define NOT_CONNECTED 0
 
 # include <iostream>
 # include <netinet/in.h>
@@ -17,6 +19,10 @@
 # include <sys/time.h>
 # include <sys/select.h>
 # include "Server.hpp"
+# include "Client.hpp"
+# include "Channel.hpp"
+# include <set>
+# include <exception>
 
 
 #endif


### PR DESCRIPTION
Now using two buffers in Client class, they are std::string(s) write/read buffers
The server still uses a char buffer[IRC_BUFFER_SIZE] to fill them.
This will be easier to concatenate and trim messages that are received and need to be sent.

Creating a class Channel to represent the channels.

Storing everything on the stack using stl allocaters.
No longer relying on destructors to close open fds.

This causes another issue that will be dealt with later, in case of an abrupt interruption
all the fds must be properly closed in a signal handler, leading to the use of a global variable.

Co-authored-by: aweaver [aweaver@student.42.fr](mailto:aweaver@student.42.fr)
Co-authored-by: elouisia [elouisiade@live.fr](mailto:elouisiade@live.fr)
