### PR TITLE
MERGE SIGNAL HANDLER && FIX LEAKS SERVER DESTRUCTOR:

### DIFF
--- a/Server.cpp
+++ b/Server.cpp
@@ -81,6 +81,9 @@ Server::~Server()
 #if SHOW_CONSTRUCTOR
 	std::cout << "Server destructor" << std::endl;
 #endif
+	for (std::map<int, Client>::iterator it = this->_clients.begin();
+		it != this->_clients.end(); it++)
+		close(it->second.getSocketFD());
 	close(this->_socketFD);
 }
 
@@ -182,12 +185,17 @@ Server& Server::operator=(const Server &rhs)
 
 const char *Server::CannotRetrieveSocketException::what(void) const throw()
 {
-	return ("Aborting\n");
+	return ("cannot retrieve socket");
 }
 
 const char *Server::CannotRetrieveAddrinfoException::what(void) const throw()
 {
-	return ("Aborting\n");
+	return ("cannot retrieve AddrInfo");
+}
+
+const char *Server::InterruptionSignalException::what(void) const throw()
+{
+	return ("Program Interrupted");
 }
 
 void	Server::socketErrorHandler(int errorBitField) const

--- a/Server.hpp
+++ b/Server.hpp
@@ -57,6 +57,13 @@ class Server
 			public:
 				const char* what(void) const throw();
 		};
+
+		class InterruptionSignalException : public std::exception
+		{
+			public:
+				const char* what(void) const throw();
+		};
+
 	private:
 	protected:
 		int				_socketFD;

--- a/irc.hpp
+++ b/irc.hpp
@@ -29,6 +29,7 @@
 # include <list>
 # include <map>
 # include <exception>
+# include <csignal>
 # include "Server.hpp"
 # include "Client.hpp"
 # include "Channel.hpp"

--- a/main.cpp
+++ b/main.cpp
@@ -1,17 +1,3 @@
-#include <iostream>
-#include <netinet/in.h>
-#include <cstdlib>
-#include <cstring>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <netdb.h>
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include <cerrno>
-#include <unistd.h>
-#include <fcntl.h>
-#include <sys/time.h>
-#include <sys/select.h>
 #include "irc.hpp"
 
 // int setsockopt(int sockfd, int level, int optname,  const void *optval, socklen_t optlen);
@@ -29,6 +15,12 @@ void *get_in_addr(struct sockaddr *sa)
 	return &(((struct sockaddr_in6*)sa)->sin6_addr);
 }
 
+void sigIntHandler(int signal)
+{
+	(void)signal;
+	throw Server::InterruptionSignalException();
+}
+
 int main( int ac, char** av ) {
 
 	// if (ac != 2)
@@ -37,13 +29,15 @@ int main( int ac, char** av ) {
 	// 	return 1;
 	// }
 
+
 	(void)ac;
 	(void)av;
 
 	try
 	{
-		Server	myIrc("3490", NULL);
+		std::signal(SIGINT, sigIntHandler);
 
+		Server	myIrc("3490", NULL);
 		std::cout << "entering the while loop" << std::endl;
 		/* WAITING FOR CONNECTIONS LOOP */
 		while(1)
@@ -60,7 +54,6 @@ int main( int ac, char** av ) {
 	catch (std::exception &e)
 	{
 		std::cerr << "Abort: " << e.what() << std::endl;
-		exit(1);
 	}
 	return 0;
 }


### PR DESCRIPTION
Interruption signal is thrown and caught with an exception. 
Server destructor loops through all the clients to close their fds before closing the listening socket.
exit(1) is removed from the catch in the main since it prevented the program to cleanly free the stack.
Messages returned by the exceptions are reworded to improve accuracy.
Header files declaration is removed from main.cpp to be solely declared in irc.hpp

Co-authored-by: aweaver [aweaver@student.42.fr](mailto:aweaver@student.42.fr)
Co-authored-by: elouisia [elouisiade@live.fr](mailto:elouisiade@live.fr)