### PR TITLE
MERGE IMPROVED OOP DESTROY CHANNEL && KICK:

### DIFF
--- a/Channel.cpp
+++ b/Channel.cpp
@@ -58,7 +58,7 @@ void	Channel::updateChannelName(std::string name)
 	this->_name = name;
 }
 
-int		Channel::isUserConnected(Client& user)
+bool		Channel::isUserConnected(Client& user)
 {
 	std::map<int, Client*>::iterator it = this->_connectedClients.find(user.getSocketFD());
 	if (it != this->_connectedClients.end())
@@ -76,6 +76,7 @@ bool	isCaseInsensitiveEqual(std::string str1, std::string str2)
 	return (true);
 }
 
+
 bool Channel::isUserConnected(std::string nickName)
 {
 	std::map<int, Client*>::iterator it;
@@ -86,6 +87,17 @@ bool Channel::isUserConnected(std::string nickName)
 			return true;
 	}
 	return false;
+}
+
+Client	*Channel::getUserIfConnected(std::string userName)
+{
+	for (std::map<int, Client*>::iterator it = this->_connectedClients.begin();
+		it != this->_connectedClients.end(); it++)
+	{
+		if (userName == it->second->getUsername())
+			return (it->second);
+	}
+	return (NULL);
 }
 
 void	Channel::addUserToChannel(Client& user)

--- a/Channel.cpp
+++ b/Channel.cpp
@@ -48,6 +48,11 @@ bool Channel::operator<(const Channel &rhs) const
 	return (this->_name < rhs._name);
 }
 
+bool Channel::operator==(const Channel &rhs) const
+{
+	return (this->_name == rhs._name);
+}
+
 std::string	Channel::getName() const
 {
 	return (this->_name);

--- a/Channel.hpp
+++ b/Channel.hpp
@@ -11,10 +11,13 @@ class Channel
 		~Channel();
 		Channel(const Channel &source);
 		Channel &operator=(const Channel &rhs);
-		bool operator<(const Channel &rhs) const;
 		Channel(std::string name, Client& owner);
 
 		void	updateChannelName(std::string);
+
+		/* comparison operators */
+		bool operator<(const Channel &rhs) const;
+		bool operator==(const Channel &rhs) const;
 
 		/* getters */
 		std::string getName() const;

--- a/Channel.hpp
+++ b/Channel.hpp
@@ -20,8 +20,9 @@ class Channel
 		std::string getName() const;
 
 		/* users handler */
-		int		isUserConnected(Client& user);
+		bool	isUserConnected(Client& user);
 		bool	isUserConnected(std::string userName);
+		Client	*getUserIfConnected(std::string userName);
 		int		removeUserFromChannel(Client& user);
 		void	addUserToChannel(Client&);
 

--- a/Kick.cpp
+++ b/Kick.cpp
@@ -62,14 +62,15 @@ void Kick::execute() const
 		return ;
 	}
 
-	/* Is the user the user wants to kick conected to that channel ?*/
-	std::string targetName = this->_cmd[2];
-		if (!foundChannel->isUserConnected(*(this->_user)))
+	/* Is the target_user the author wants to kick conected to that channel ?*/
+	Client *foundClient;
+	if ((foundClient = foundChannel->getUserIfConnected(this->_cmd[2])) == NULL)
 	{
 		error(ERR_NOTONCHANNEL);
 		return ;
 	}
-
+	if (foundChannel->removeUserFromChannel(*foundClient) == 0)
+		this->_server->destroyChannel(*foundChannel);
 }
 
 void Kick::error( int errorCode ) const

--- a/Server.cpp
+++ b/Server.cpp
@@ -421,26 +421,31 @@ void	Server::createChannel(std::string newChannelName, Client& owner)
 	}
 }
 
-void	Server::destroyChannel(const Channel& chanToDelete)
+void	Server::destroyChannel(Channel& chanToDelete)
 {
-	(void)chanToDelete;
-	//supprimer le chan dans la liste de chaque personne connectée
-	//supprimer le chan dans Server
+	for (std::map<int, Client>::iterator clientIterator = this->_clients.begin();
+		clientIterator != this->_clients.end(); clientIterator++)
+	{
+			clientIterator->second.quitChannel(chanToDelete);
+	}
+	for (std::deque<Channel>::iterator channelIterator = this->_channels.begin();
+		channelIterator != this->_channels.end(); channelIterator++)
+	{
+		if (*channelIterator == chanToDelete)
+		{
+			this->_channels.erase(channelIterator);
+			break;
+		}
+	}
 }
 
 void	Server::destroyChannel(std::string channelName)
 {
-	for (std::deque<Channel>::iterator it = this->_channels.begin();
-		it != this->_channels.end(); it++)
-	{
-		if (it->getName() == channelName)
-		{
-			this->destroyChannel(*it);
-			break;
-		}
-	}
-	//trouver le channel dans la liste de Server
-	//appeler destroychannel(Channel&)
+	Channel *foundChannel;
+	foundChannel = this->getChannelIfExist(channelName);
+	if (foundChannel == NULL)
+		return ;
+	this->destroyChannel(*foundChannel);
 }
 
 Channel	*Server::getChannelIfExist(std::string chanName)

--- a/Server.cpp
+++ b/Server.cpp
@@ -240,7 +240,19 @@ bool	Server::isUserConnected(std::string userName) const
 		}
 	}
 	return false;
+}
 
+Client	*Server::getUserIfConnected(std::string userName)
+{
+	for (std::map<int, Client>::iterator it = this->_clients.begin();
+		it != this->_clients.end(); it++)
+	{
+		if (userName == it->second.getUsername())
+		{
+			return (&(it->second));
+		}
+	}
+	return (NULL);
 }
 
 void	Server::connectUser(const int socketFD)

--- a/Server.hpp
+++ b/Server.hpp
@@ -37,6 +37,7 @@ class Server
 		void	disconnectUser(std::map<int, Client>::iterator clientIterator);
 		void	checkNewConnections();
 		bool	isUserConnected(std::string) const;
+		Client	*getUserIfConnected(std::string nickName);
 
 		/* Channel handlers */
 		void	createChannel(std::string, Client&);

--- a/Server.hpp
+++ b/Server.hpp
@@ -41,7 +41,7 @@ class Server
 
 		/* Channel handlers */
 		void	createChannel(std::string, Client&);
-		void	destroyChannel(const Channel&);
+		void	destroyChannel(Channel&);
 		void	destroyChannel(std::string);
 		Channel	*getChannelIfExist(std::string chanName);
 


### PR DESCRIPTION
Added changes to Elouisia's work on parsing command and KICK command.

Now using a more OOP way of doing things.
Kick command should now actually remove users from channels.
Still need to sort out the error handlers.

Destroying channels now actually destroy channels.

Co-authored-by: aweaver [aweaver@student.42.fr](mailto:aweaver@student.42.fr)
Co-authored-by: elouisia [elouisiade@live.fr](mailto:elouisiade@live.fr)
