### PR TITLE
MERGE NICK CMD NICK/USER/HOSTNAME REWORK:

### DIFF
--- a/ACommand.cpp
+++ b/ACommand.cpp
@@ -9,10 +9,10 @@ ACommand::~ACommand()
 {
 }
 
-ACommand::ACommand(Server &server, Client &user, std::string rawInput)
+ACommand::ACommand(Server &server, Client &author, std::string rawInput)
 {
 	this->_server = &server;
-	this->_user = &user;
+	this->_author = &author;
 	this->tokenise(rawInput);
 }
 
@@ -24,7 +24,7 @@ ACommand::ACommand(const ACommand &source)
 ACommand &ACommand::operator=(const ACommand &rhs)
 {
 	this->_cmd = rhs._cmd;
-	this->_user = rhs._user;
+	this->_author = rhs._author;
 	return (*this);
 }
 

--- a/ACommand.hpp
+++ b/ACommand.hpp
@@ -14,7 +14,7 @@ class ACommand
 
 	protected:
 		ACommand();
-		ACommand(Server &server, Client &user, std::string cmd);
+		ACommand(Server &server, Client &author, std::string cmd);
 		ACommand(const ACommand &source);
 		ACommand &operator=(const ACommand &rhs);
 
@@ -27,7 +27,7 @@ class ACommand
 		//void	*_target;
 
 		Server	*_server;
-		Client	*_user;
+		Client	*_author;
 		std::deque<std::string>	_cmd;
 	private:
 		void	tokenise(std::string rawInput);

--- a/ACommand.hpp
+++ b/ACommand.hpp
@@ -21,6 +21,7 @@ class ACommand
 
 		virtual void	execute() const = 0;
 		virtual void	error(int errorCode) const = 0;
+		virtual void	confirm() const = 0;
 
 		//TODO: create a bool for the target to be used in derived classes
 		//bool	targetIsUserOrChannel;

--- a/Channel.cpp
+++ b/Channel.cpp
@@ -82,7 +82,7 @@ bool Channel::isUserConnected(std::string nickName)
 	for (it = this->_connectedClients.begin();
 		it != this->_connectedClients.end(); it++)
 	{
-		if (isCaseInsensitiveEqual(it->second->getUsername(), nickName))
+		if (isCaseInsensitiveEqual(it->second->getNickname(), nickName))
 			return true;
 	}
 	return false;

--- a/Channel.cpp
+++ b/Channel.cpp
@@ -94,12 +94,12 @@ bool Channel::isUserConnected(std::string nickName)
 	return false;
 }
 
-Client	*Channel::getUserIfConnected(std::string userName)
+Client	*Channel::getUserIfConnected(std::string nickname)
 {
 	for (std::map<int, Client*>::iterator it = this->_connectedClients.begin();
 		it != this->_connectedClients.end(); it++)
 	{
-		if (userName == it->second->getUsername())
+		if (nickname == it->second->getNickname())
 			return (it->second);
 	}
 	return (NULL);

--- a/Client.cpp
+++ b/Client.cpp
@@ -36,13 +36,13 @@ Client& Client::operator=(const Client &rhs)
 	std::cout << "Client = overload" << std::endl;
 #endif
 	this->_socketFD = rhs._socketFD;
-	this->_username = rhs._username;
+	this->_nickname = rhs._nickname;
 	return (*this);
 }
 
-void	Client::setUsername(std::string name)
+void	Client::setNickname(std::string name)
 {
-	this->_username = name;
+	this->_nickname = name;
 }
 
 int	Client::getSocketFD() const
@@ -50,15 +50,21 @@ int	Client::getSocketFD() const
 	return (this->_socketFD);
 }
 
-std::string Client::getUsername() const
+std::string Client::getNickname() const
 {
-	return (this->_username);
+	return (this->_nickname);
+}
+
+std::string Client::getFullName() const
+{
+	return (this->_nickname + "!" + this->_username + "@" + this->_hostname);
 }
 
 const std::set<Channel*> &Client::getConnectedChannels() const
 {
 	return (this->_connectedChannels);
 }
+
 int	Client::isInChannel(Channel& toFind) const
 {
 	if (this->_connectedChannels.find(&toFind) != this->_connectedChannels.end())

--- a/Client.cpp
+++ b/Client.cpp
@@ -55,6 +55,10 @@ std::string Client::getUsername() const
 	return (this->_username);
 }
 
+const std::set<Channel*> &Client::getConnectedChannels() const
+{
+	return (this->_connectedChannels);
+}
 int	Client::isInChannel(Channel& toFind) const
 {
 	if (this->_connectedChannels.find(&toFind) != this->_connectedChannels.end())

--- a/Client.hpp
+++ b/Client.hpp
@@ -13,11 +13,13 @@ class Client
 		Client& operator=(const Client &rhs);
 		Client(int);
 
-		void	setUsername(std::string name);
+		/* Setters */
+		void	setNickname(std::string name);
 
 		/* Getters */
 		int	getSocketFD() const;
-		std::string getUsername() const;
+		std::string getNickname() const;
+		std::string getFullName() const;
 		const std::set<Channel*> &getConnectedChannels() const;
 
 		std::string	readBuffer;
@@ -32,7 +34,9 @@ class Client
 
 		/* Attributes */
 		int			_socketFD;
-		std::string	_username;
+		std::string	_nickname;
+		std::string _username;
+		std::string	_hostname;
 		std::set<Channel*> _connectedChannels;
 	protected:
 };

--- a/Client.hpp
+++ b/Client.hpp
@@ -18,6 +18,7 @@ class Client
 		/* Getters */
 		int	getSocketFD() const;
 		std::string getUsername() const;
+		const std::set<Channel*> &getConnectedChannels() const;
 
 		std::string	readBuffer;
 		std::string writeBuffer;

--- a/Join.hpp
+++ b/Join.hpp
@@ -5,16 +5,6 @@
 # include <string>
 # include "ACommand.hpp"
 
-# define ERR_NEEDMOREPARAMS 461
-# define ERR_BANNEDFROMCHAN 474
-# define ERR_INVITEONLYCHAN 473
-# define ERR_BADCHANNELKEY 475
-# define ERR_CHANNELISFULL 471
-# define ERR_BADCHANMASK 476
-# define ERR_NOSUCHCHANNEL 403
-# define ERR_TOOMANYCHANNELS 405
-# define RPL_TOPIC 332
-
 class Client;
 class Server;
 class Join : public ACommand

--- a/Kick.cpp
+++ b/Kick.cpp
@@ -63,8 +63,7 @@ void Kick::execute() const
 	}
 
 	/* Is the user the user wants to kick conected to that channel ?*/
-	std::string targetName = this->_cmd[2];
-		if (!foundChannel->isUserConnected(*(this->_author)))
+	if (!foundChannel->isUserConnected(this->_cmd[2]))
 	{
 		error(ERR_NOTONCHANNEL);
 		return ;

--- a/Kick.cpp
+++ b/Kick.cpp
@@ -4,7 +4,7 @@ Kick::Kick() : ACommand()
 {
 }
 
-Kick::Kick( Kick const & src )
+Kick::Kick( Kick const & src ) : ACommand(src)
 {
 	*this = src;
 }
@@ -70,6 +70,10 @@ void Kick::execute() const
 	}
 	if (foundChannel->removeUserFromChannel(*foundClient) == 0)
 		this->_server->destroyChannel(*foundChannel);
+}
+
+void	Kick::confirm() const
+{
 }
 
 void Kick::error( int errorCode ) const

--- a/Kick.cpp
+++ b/Kick.cpp
@@ -12,7 +12,7 @@ Kick::Kick( Kick const & src )
 Kick::Kick(Server &server, Client &user, std::string rawInput) : ACommand(server, user, rawInput)
 {
 	std::cout << "KICK overloaded constructor" << std::endl;
-	std::cout << "client socketFD : " << this->_user->getSocketFD() << std::endl;
+	std::cout << "client socketFD : " << this->_author->getSocketFD() << std::endl;
 	this->execute();
 }
 
@@ -22,7 +22,7 @@ Kick & Kick::operator=( Kick const & rhs )
 	{
 		this->_cmd = rhs._cmd;
 		this->_server = rhs._server;
-		this->_user = rhs._user;
+		this->_author = rhs._author;
 	}
 	return *this;
 }
@@ -49,14 +49,14 @@ void Kick::execute() const
 	}
 
 	/* Is the user connected to that channel ? */
-	if (!foundChannel->isUserConnected(*(this->_user)))
+	if (!foundChannel->isUserConnected(*(this->_author)))
 	{
 		error(ERR_NOTONCHANNEL);
 		return ;
 	}
 
 	/* Is the user a Channel Operator ? */
-	if (!foundChannel->isChannelOperator(*(this->_user)))
+	if (!foundChannel->isChannelOperator(*(this->_author)))
 	{
 		error(ERR_CHANOPRIVSNEEDED);
 		return ;
@@ -64,7 +64,7 @@ void Kick::execute() const
 
 	/* Is the user the user wants to kick conected to that channel ?*/
 	std::string targetName = this->_cmd[2];
-		if (!foundChannel->isUserConnected(*(this->_user)))
+		if (!foundChannel->isUserConnected(*(this->_author)))
 	{
 		error(ERR_NOTONCHANNEL);
 		return ;
@@ -77,13 +77,13 @@ void Kick::error( int errorCode ) const
 	std::string errorMsg;
 	errorMsg += errorCode;
 	errorMsg += ":";
-	errorMsg += this->_user->getUsername();
+	errorMsg += this->_author->getNickname();
 	errorMsg += this->_cmd[0];
 	errorMsg += "\n";
 // switch (errorCode)
 // {
 // case /* constant-expression :*/
-// 	/* this->_user->write_buffer += errorMsg; */
+// 	/* this->_author->write_buffer += errorMsg; */
 // 	// break;
 
 // // default:

--- a/Kick.hpp
+++ b/Kick.hpp
@@ -19,8 +19,9 @@ class Kick : public ACommand
 		Kick & operator=( Kick const & rhs );
 		~Kick();
 
-		void execute( void ) const;
-		void error( int errorCode ) const;
+		void	execute( void ) const;
+		void	error( int errorCode ) const;
+		void	confirm() const;
 };
 
 #endif

--- a/Kick.hpp
+++ b/Kick.hpp
@@ -4,13 +4,6 @@
 # include "ACommand.hpp"
 # include "irc.hpp"
 
-# define ERR_NEEDMOREPARAMS 461
-# define ERR_NOSUCHCHANNEL 403
-# define ERR_NOTONCHANNEL 442
-# define ERR_BADCHANMASK 476
-# define ERR_CHANOPRIVSNEEDED 482
-# define ERR_USERNOTINCHANNEL 441
-
 class Client;
 class Server;
 class Kick : public ACommand

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ re: clean
 	@make all
 
 test: $(NAME)
-		./$(NAME)
+		./$(NAME) 3490
 
 vtest:	$(NAME)
 		valgrind --leak-check=full --track-fds=yes ./$(NAME)

--- a/Nick.cpp
+++ b/Nick.cpp
@@ -54,33 +54,36 @@ void Nick::execute() const
 	//No condition for ERR_NICKCOLLISION not required by subject
 	std::string message;
 	message += this->_author->getNickname() + " changed his nickname to " + newName + ".\r\n";
-	this->_server->broadcastAllClients(message);
+	this->confirm();
 }
 
 void Nick::error(int errorCode) const
 {
-	std::stringstream converter;
-	std::string errorMessage;
-	if (errorCode != ERR_NONICKNAMEGIVEN)
-	{
-		converter << errorCode << " :" << this->_author->getNickname() << " "
-			<< this->_cmd[1];
-		errorMessage = converter.str();
-	}
+	std::stringstream errorMessage;
+	errorMessage << ":" << this->_server->getHostname() << " " << errorCode << " "
+	<< this->_author->getNickname();
 	switch (errorCode)
 	{
 		case ERR_NONICKNAMEGIVEN:
-			errorMessage += this->_author->getNickname() + ": No nickname given\r\n";
+			errorMessage << " :" << ERR_NONICKNAMEGIVEN_MSG << CRLF;
 			break;
 		case ERR_ERRONEUSNICKNAME:
-			errorMessage += "Erroneus nickname\r\n";
+			errorMessage << this->_cmd[1] << " :" << ERR_ERRONEUSNICKNAME_MSG << CRLF;
 			break;
 		case ERR_NICKNAMEINUSE:
-			errorMessage += "Nickname is already in use\r\n";
+			errorMessage << this->_cmd[1] << " :" << ERR_NICKNAMEINUSE_MSG << CRLF;
 			break;
 		default:
 			std::cerr << "Error: Unrecognised error code." << std::endl;
 			break;
 	}
-	this->_author->writeBuffer += errorMessage;
+	this->_author->writeBuffer += errorMessage.str();
+}
+
+void	Nick::confirm() const
+{
+	std::stringstream replyMessageBuilder;
+	replyMessageBuilder << ":" << this->_author->getFullName() << this->_cmd[0] << " "  << this->_cmd[1];
+	std::string replyMessage = replyMessageBuilder.str();
+	this->_server->broadcastAllClients(replyMessage);
 }

--- a/Nick.cpp
+++ b/Nick.cpp
@@ -16,7 +16,7 @@ Nick::Nick(Server &server, Client &author, std::string rawInput) : ACommand(serv
 	this->execute();
 }
 
-Nick::Nick(const Nick &source)
+Nick::Nick(const Nick &source) : ACommand(source)
 {
 	*this = source;
 }

--- a/Nick.cpp
+++ b/Nick.cpp
@@ -11,7 +11,7 @@ Nick::~Nick()
 {
 }
 
-Nick::Nick(Server &server, Client &user, std::string rawInput) : ACommand(server, user, rawInput)
+Nick::Nick(Server &server, Client &author, std::string rawInput) : ACommand(server, author, rawInput)
 {
 	this->execute();
 }
@@ -24,7 +24,7 @@ Nick::Nick(const Nick &source)
 Nick &Nick::operator=(const Nick &rhs)
 {
 	this->_cmd = rhs._cmd;
-	this->_user = rhs._user;
+	this->_author = rhs._author;
 	return (*this);
 }
 
@@ -44,16 +44,16 @@ void Nick::execute() const
 			return ;
 		}
 	}
-	
+
 	if (!this->_server->isUserConnected(newName))
 	{
 		error(ERR_NICKNAMEINUSE);
 		return ;
 	}
-	
+
 	//No condition for ERR_NICKCOLLISION not required by subject
 	std::string message;
-	message += this->_user->getUsername() + " changed his nickname to " + newName + ".\r\n";
+	message += this->_author->getNickname() + " changed his nickname to " + newName + ".\r\n";
 	this->_server->broadcastAllClients(message);
 }
 
@@ -63,14 +63,14 @@ void Nick::error(int errorCode) const
 	std::string errorMessage;
 	if (errorCode != ERR_NONICKNAMEGIVEN)
 	{
-		converter << errorCode << " :" << this->_user->getUsername() << " "
+		converter << errorCode << " :" << this->_author->getNickname() << " "
 			<< this->_cmd[1];
 		errorMessage = converter.str();
 	}
 	switch (errorCode)
 	{
 		case ERR_NONICKNAMEGIVEN:
-			errorMessage += this->_user->getUsername() + ": No nickname given\r\n";
+			errorMessage += this->_author->getNickname() + ": No nickname given\r\n";
 			break;
 		case ERR_ERRONEUSNICKNAME:
 			errorMessage += "Erroneus nickname\r\n";
@@ -82,5 +82,5 @@ void Nick::error(int errorCode) const
 			std::cerr << "Error: Unrecognised error code." << std::endl;
 			break;
 	}
-	this->_user->writeBuffer += errorMessage;
+	this->_author->writeBuffer += errorMessage;
 }

--- a/Nick.hpp
+++ b/Nick.hpp
@@ -17,7 +17,7 @@ class Nick : public ACommand
 		~Nick();
 
 	protected:
-		Nick(Server &server, Client &user, std::string rawInput);
+		Nick(Server &server, Client &author, std::string rawInput);
 		Nick(const Nick &source);
 		Nick &operator=(const Nick &rhs);
 

--- a/Nick.hpp
+++ b/Nick.hpp
@@ -4,28 +4,23 @@
 # include <list>
 # include <string>
 
-# define ERR_NONICKNAMEGIVEN 431
-# define ERR_ERRONEUSNICKNAME 432
-# define ERR_NICKNAMEINUSE 433
-# define ERR_NICKCOLLISION 436
-
 class Client;
 class Server;
 class Nick : public ACommand
 {
 	public:
 		~Nick();
-
-	protected:
 		Nick(Server &server, Client &author, std::string rawInput);
 		Nick(const Nick &source);
 		Nick &operator=(const Nick &rhs);
 
-		void	execute() const;
-		void	error(int errorCode) const;
+	protected:
 
 	private:
 		Nick();
+		void	execute() const;
+		void	confirm() const;
+		void	error(int errorCode) const;
 };
 
 #endif

--- a/Server.cpp
+++ b/Server.cpp
@@ -165,6 +165,11 @@ int	Server::getSocketFD() const
 	return (this->_socketFD);
 }
 
+const std::string &Server::getHostname() const
+{
+	return (this->_hostname);
+}
+
 std::map<int, Client> &Server::getClients()
 {
 	return (this->_clients);

--- a/Server.cpp
+++ b/Server.cpp
@@ -45,7 +45,6 @@ Server::Server(const char *portNumber)
 				focus->ai_protocol);
 		if (this->_socketFD < 0)
 		{
-			std::cerr << "error 1 " << std::endl;
 			errorCode |= ERRSOCKFD;
 			continue;
 		}
@@ -55,7 +54,6 @@ Server::Server(const char *portNumber)
 		if (setsockopt(this->_socketFD, SOL_SOCKET,
 				SO_REUSEADDR | SO_REUSEPORT, &opt, sizeof(opt)) < 0)
 		{
-			std::cerr << "error 2 " << std::endl;
 			errorCode |= ERRSOCKOPT;
 			continue;
 		}
@@ -64,7 +62,6 @@ Server::Server(const char *portNumber)
 		int flag = fcntl(this->_socketFD, F_GETFL, 0);
 		if (fcntl(this->_socketFD, F_SETFL, flag | O_NONBLOCK) < 0)
 		{
-			std::cerr << "error 3 " << std::endl;
 			errorCode |= ERRSOCKNOBLOCK;
 			continue;
 		}
@@ -72,14 +69,12 @@ Server::Server(const char *portNumber)
 		/* binds the socket descriptor to the port passed to getaddrinfo() */
 		if (bind(this->_socketFD, focus->ai_addr, focus->ai_addrlen) < 0)
 		{
-			std::cerr << "error 4 " << std::endl;
 			errorCode |= ERRSOCKBIND;
 			continue;
 		}
 		/* listens to the port bound to the socket descriptor for incoming connections */
 		if (listen(this->_socketFD, MYIRC_ALLOWED_PENDING_CONNECTIONS) < 0)
 		{
-			std::cerr << "error 5 " << std::endl;
 			errorCode |= ERRSOCKLISTEN;
 			continue;
 		}
@@ -180,12 +175,12 @@ std::deque<Channel> & Server::getChannels( void )
 	return this->_channels;
 }
 
-bool	Server::isUserConnected(std::string userName) const
+bool	Server::isUserConnected(std::string nickname) const
 {
 	for (std::map<int, Client>::const_iterator it = this->_clients.begin();
 		it != this->_clients.end(); it++)
 	{
-		if (userName == it->second.getNickname())
+		if (nickname == it->second.getNickname())
 		{
 			return true;
 		}
@@ -193,12 +188,12 @@ bool	Server::isUserConnected(std::string userName) const
 	return false;
 }
 
-Client	*Server::getUserIfConnected(std::string userName)
+Client	*Server::getUserIfConnected(std::string nickname)
 {
 	for (std::map<int, Client>::iterator it = this->_clients.begin();
 		it != this->_clients.end(); it++)
 	{
-		if (userName == it->second.getUsername())
+		if (nickname == it->second.getNickname())
 		{
 			return (&(it->second));
 		}

--- a/Server.cpp
+++ b/Server.cpp
@@ -2,78 +2,6 @@
 
 Server::Server()
 {
-#if SHOW_CONSTRUCTOR
-	std::cout << "Server Default constructor" << std::endl;
-#endif
-	int				status = 0;
-	struct addrinfo hints;
-	struct addrinfo	*servinfo;
-
-	this->_fdMax = 0;
-	memset(&hints, 0, sizeof(hints));
-	hints.ai_family = AF_UNSPEC;
-	hints.ai_socktype = SOCK_STREAM;
-	hints.ai_flags = AI_PASSIVE;
-
-	if ((status = getaddrinfo(NULL, MYIRC_PORT,  &hints, &servinfo)) != 0)
-	{
-		std::cerr << gai_strerror(status) << std::endl;
-		throw Server::CannotRetrieveAddrinfoException();
-	}
-	for (struct addrinfo *focus = servinfo; focus != NULL; focus = focus->ai_next)
-	{
-		/* retrieving a socket file descriptor */
-		this->_socketFD = socket(focus->ai_family, focus->ai_socktype,
-				focus->ai_protocol);
-		if (this->_socketFD < 0)
-		{
-			status |= 1;
-			continue;
-		}
-
-		/* sets the descriptor as reusable */
-		int opt = 1;
-		if (setsockopt(this->_socketFD, SOL_SOCKET,
-				SO_REUSEADDR | SO_REUSEPORT, &opt, sizeof(opt)) < 0)
-		{
-			status |= 0b10;
-			continue;
-		}
-
-		/* sets the socket as non blocking */
-		int flag = fcntl(this->_socketFD, F_GETFL, 0);
-		if (fcntl(this->_socketFD, F_SETFL, flag | O_NONBLOCK) < 0)
-		{
-			status |= 0b100;
-			continue;
-		}
-
-		/* binds the socket descriptor to the port passed to getaddrinfo() */
-		if (bind(this->_socketFD, focus->ai_addr, focus->ai_addrlen) < 0)
-		{
-			status |= 0b1000;
-			continue;
-		}
-		/* listens to the port bound to the socket descriptor for incoming connections */
-		if (listen(this->_socketFD, MYIRC_ALLOWED_PENDING_CONNECTIONS) < 0)
-		{
-			status |= 0b10000;
-			continue;
-		}
-	}
-	freeaddrinfo(servinfo);
-	if (status != 0)
-	{
-		this->socketErrorHandler(status);
-		throw Server::CannotRetrieveSocketException();
-	}
-	FD_ZERO(&(this->_masterSet));
-	FD_ZERO(&(this->_readingSet));
-	FD_ZERO(&(this->_writingSet));
-	FD_SET(this->_socketFD, &(this->_masterSet)); //add the current socket descriptor to the set
-	if (this->_socketFD > this->_fdMax)
-		this->_fdMax = this->_socketFD;
-	this->_pendingAddrSize = sizeof(this->_pendingAddr);
 }
 
 Server::~Server()
@@ -87,22 +15,24 @@ Server::~Server()
 	close(this->_socketFD);
 }
 
-Server::Server(const char *portNumber, const char *domain)
+Server::Server(const char *portNumber)
 {
 #if SHOW_CONSTRUCTOR
 	std::cout << "Server char* char* constructor" << std::endl;
 #endif
-	int				status = 0;
+	int	status = 0;
+	unsigned int	errorCode = 0;
 	struct addrinfo hints;
 	struct addrinfo	*servinfo;
 
+	this->_hostname = "mismatched_sock(et)s_irc";
 	this->_fdMax = 0;
 	memset(&hints, 0, sizeof(hints));
 	hints.ai_family = AF_UNSPEC;
 	hints.ai_socktype = SOCK_STREAM;
 	hints.ai_flags = AI_PASSIVE;
 
-	if ((status = getaddrinfo(domain, portNumber, &hints, &servinfo)) != 0)
+	if ((status = getaddrinfo(NULL, portNumber, &hints, &servinfo)) != 0)
 	{
 		std::cerr << gai_strerror(status) << std::endl;
 		throw Server::CannotRetrieveAddrinfoException();
@@ -115,7 +45,8 @@ Server::Server(const char *portNumber, const char *domain)
 				focus->ai_protocol);
 		if (this->_socketFD < 0)
 		{
-			status |= 1;
+			std::cerr << "error 1 " << std::endl;
+			errorCode |= ERRSOCKFD;
 			continue;
 		}
 
@@ -124,7 +55,8 @@ Server::Server(const char *portNumber, const char *domain)
 		if (setsockopt(this->_socketFD, SOL_SOCKET,
 				SO_REUSEADDR | SO_REUSEPORT, &opt, sizeof(opt)) < 0)
 		{
-			status |= 0b10;
+			std::cerr << "error 2 " << std::endl;
+			errorCode |= ERRSOCKOPT;
 			continue;
 		}
 
@@ -132,28 +64,39 @@ Server::Server(const char *portNumber, const char *domain)
 		int flag = fcntl(this->_socketFD, F_GETFL, 0);
 		if (fcntl(this->_socketFD, F_SETFL, flag | O_NONBLOCK) < 0)
 		{
-			status |= 0b100;
+			std::cerr << "error 3 " << std::endl;
+			errorCode |= ERRSOCKNOBLOCK;
 			continue;
 		}
 
 		/* binds the socket descriptor to the port passed to getaddrinfo() */
 		if (bind(this->_socketFD, focus->ai_addr, focus->ai_addrlen) < 0)
 		{
-			status |= 0b1000;
+			std::cerr << "error 4 " << std::endl;
+			errorCode |= ERRSOCKBIND;
 			continue;
 		}
 		/* listens to the port bound to the socket descriptor for incoming connections */
 		if (listen(this->_socketFD, MYIRC_ALLOWED_PENDING_CONNECTIONS) < 0)
 		{
-			status |= 0b10000;
+			std::cerr << "error 5 " << std::endl;
+			errorCode |= ERRSOCKLISTEN;
 			continue;
 		}
+		//this could have been what we would have used if getnameinfo was allowed in the subject
+		//char			hostname[HOST_BUFFER_SIZE + 1];
+		//char			servname[SERV_BUFFER_SIZE + 1];
+		//if ((status = getnameinfo(focus->ai_addr, focus->ai_addrlen,
+				//hostname, HOST_BUFFER_SIZE, servname, SERV_BUFFER_SIZE, NI_NAMEREQD)) == 0)
+		//{
+			//this->_hostname = hostname;
+		//}
 		break;
 	}
 	freeaddrinfo(servinfo);
-	if (status != 0 || focus == NULL)
+	if (errorCode != 0 || focus == NULL)
 	{
-		this->socketErrorHandler(status);
+		this->socketErrorHandler(errorCode);
 		throw Server::CannotRetrieveSocketException();
 	}
 	FD_ZERO(&(this->_masterSet));
@@ -198,8 +141,9 @@ const char *Server::InterruptionSignalException::what(void) const throw()
 	return ("Program Interrupted");
 }
 
-void	Server::socketErrorHandler(int errorBitField) const
+void	Server::socketErrorHandler(unsigned int errorBitField) const
 {
+	std::cout << errorBitField << std::endl;
 	if (errorBitField & (errorBitField - 1))
 		std::cerr << "multiple error encountered:" << std::endl;
 	if (errorBitField & ERRSOCKFD)
@@ -212,6 +156,8 @@ void	Server::socketErrorHandler(int errorBitField) const
 		std::cerr << "bind() failed." << std::endl;
 	if (errorBitField & ERRSOCKLISTEN)
 		std::cerr << "listen() failed." << std::endl;
+	if (errorBitField & ERRNAMERESOLVE)
+		std::cerr << "could not resolve name." << std::endl;
 }
 
 int	Server::getSocketFD() const
@@ -234,7 +180,7 @@ bool	Server::isUserConnected(std::string userName) const
 	for (std::map<int, Client>::const_iterator it = this->_clients.begin();
 		it != this->_clients.end(); it++)
 	{
-		if (userName == it->second.getUsername())
+		if (userName == it->second.getNickname())
 		{
 			return true;
 		}

--- a/Server.hpp
+++ b/Server.hpp
@@ -31,9 +31,10 @@ class Server
 		void	socketErrorHandler(unsigned int errorBitField) const;
 
 		/* Getters */
-		int		getSocketFD() const;
-		std::map<int, Client> &getClients();
-		std::deque<Channel>& getChannels();
+		int						getSocketFD() const;
+		const std::string		&getHostname() const;
+		std::map<int, Client>	&getClients();
+		std::deque<Channel>		&getChannels();
 
 		/* Client handlers */
 		void	connectUser(int);

--- a/Server.hpp
+++ b/Server.hpp
@@ -10,6 +10,10 @@
 # define ERRSOCKNOBLOCK 0b100
 # define ERRSOCKBIND 0b1000
 # define ERRSOCKLISTEN 0b10000
+# define ERRNAMERESOLVE 0b100000
+
+# define HOST_BUFFER_SIZE 255
+# define SERV_BUFFER_SIZE 255
 
 class Client;
 class Channel;
@@ -19,12 +23,12 @@ class Server
 	public:
 		Server();
 		~Server();
-		Server(const char *portNumber, const char *domain = NULL);
+		Server(const char *portNumber);
 		Server(const Server &source);
 		Server& operator=(const Server &rhs);
 
 		void	closeSocketFD();
-		void	socketErrorHandler(int errorBitField) const;
+		void	socketErrorHandler(unsigned int errorBitField) const;
 
 		/* Getters */
 		int		getSocketFD() const;
@@ -81,6 +85,7 @@ class Server
 	private:
 		int				_socketFD;
 		int				_fdMax;
+		std::string	_hostname;
 		fd_set		_masterSet;
 		fd_set		_readingSet;
 		fd_set		_writingSet;

--- a/irc.hpp
+++ b/irc.hpp
@@ -70,7 +70,7 @@
 # define ERR_BADCHANMASK_MSG "Bad Channel Mask"
 # define ERR_CHANOPRIVSNEEDED_MSG "You're not channel operator"
 
-# define CRLF "\n\r"
+# define CRLF "\r\n"
 
 
 

--- a/irc.hpp
+++ b/irc.hpp
@@ -37,5 +37,41 @@
 # include "Channel.hpp"
 # include "Kick.hpp"
 
+# define RPL_TOPIC 332
+# define ERR_NOSUCHCHANNEL 403
+# define ERR_TOOMANYCHANNELS 405
+# define ERR_NONICKNAMEGIVEN 431
+# define ERR_ERRONEUSNICKNAME 432
+# define ERR_NICKNAMEINUSE 433
+# define ERR_NICKCOLLISION 436
+# define ERR_USERNOTINCHANNEL 441
+# define ERR_NOTONCHANNEL 442
+# define ERR_NEEDMOREPARAMS 461
+# define ERR_CHANNELISFULL 471
+# define ERR_INVITEONLYCHAN 473
+# define ERR_BANNEDFROMCHAN 474
+# define ERR_BADCHANNELKEY 475
+# define ERR_BADCHANMASK 476
+# define ERR_CHANOPRIVSNEEDED 482
+
+# define ERR_NOSUCHCHANNEL_MSG "No such channel"
+# define ERR_TOOMANYCHANNELS_MSG "You have joined too many channels"
+# define ERR_NONICKNAMEGIVEN_MSG "No nickname given"
+# define ERR_ERRONEUSNICKNAME_MSG "Erroneus nickname"
+# define ERR_NICKNAMEINUSE_MSG "Nickname is already in use"
+# define ERR_NICKCOLLISION_MSG "Nickname collision KILL from "
+# define ERR_USERNOTINCHANNEL_MSG "They aren't on that channel"
+# define ERR_NOTONCHANNEL_MSG "You're not on that channel"
+# define ERR_NEEDMOREPARAMS_MSG "Not enough parameters"
+# define ERR_CHANNELISFULL_MSG "Cannot join channel (+l)"
+# define ERR_INVITEONLYCHAN_MSG "Cannot join channel (+i)"
+# define ERR_BANNEDFROMCHAN_MSG "Cannot join channel (+b)"
+# define ERR_BADCHANNELKEY_MSG "Cannot join channel (+k)"
+# define ERR_BADCHANMASK_MSG "Bad Channel Mask"
+# define ERR_CHANOPRIVSNEEDED_MSG "You're not channel operator"
+
+# define CRLF "\n\r"
+
+
 
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -23,21 +23,17 @@ void sigIntHandler(int signal)
 
 int main( int ac, char** av ) {
 
-	// if (ac != 2)
-	// {
-	// 	std::cerr << "usage: ./ircserv hostname" << std::endl;
-	// 	return 1;
-	// }
-
-
-	(void)ac;
-	(void)av;
+	if (ac != 2)
+	{
+		std::cerr << "usage: ./ircserv port_to_use" << std::endl;
+		return (1);
+	}
 
 	try
 	{
 		std::signal(SIGINT, sigIntHandler);
 
-		Server	myIrc("3490", NULL);
+		Server	myIrc(av[1]);
 		std::cout << "entering the while loop" << std::endl;
 		/* WAITING FOR CONNECTIONS LOOP */
 		while(1)


### PR DESCRIPTION
Adding the NICK command with operational reply and error messages.

Reworking the client to use _nickname _username _hostname instead of the previous _username.
Reworking the ACommand to use _author instead of _user as the author of the command.

It does not make much sense to implement NICK before USER but I did not know that before doing it.

Close #4 as this can be considered complete, though it still needs to be thoroughly tested. 

Co-authored-by: aweaver [aweaver@student.42.fr](mailto:aweaver@student.42.fr)
Co-authored-by: elouisia [elouisiade@live.fr](mailto:elouisiade@live.fr)